### PR TITLE
Ускоряю путем использования подстановщика в другом месте

### DIFF
--- a/diagnostic_context.py
+++ b/diagnostic_context.py
@@ -120,7 +120,7 @@ def measured_total(_func=None):
 
 
 if __name__ == '__main__':
-    from restrictions import SegmentsNormal
+    from restrictions import SegmentsNormal, SegmentsSpotsJoint
     from project import CADProject
     from figures import Segment
     from bindings import choose_best_bindings
@@ -133,15 +133,16 @@ if __name__ == '__main__':
         segment1_name = project.add_figure(segment1)
         segment2 = Segment((1, 1), 1, 10)
         segment2_name = project.add_figure(segment2)
-        segment3 = Segment((2, 5), -1, 10)
-        segment3_name = project.add_figure(segment3)
+        # segment3 = Segment((2, 5), -1, 10)
+        # segment3_name = project.add_figure(segment3)
 
     with measure('choose binding'):
         bb = choose_best_bindings(project.bindings, 10, 0)[0]  # end of segment 1
 
     with measure('add restrictions'):
         project.add_restriction(SegmentsNormal(), (segment1_name, segment2_name))
-        project.add_restriction(SegmentsNormal(), (segment2_name, segment3_name))
+        project.add_restriction(SegmentsSpotsJoint('start', 'start'), (segment1_name, segment2_name))
+        # project.add_restriction(SegmentsNormal(), (segment2_name, segment3_name))
 
     with measure('move segment 1 end'):
         project.move_figure(bb, 10 + 1, 0)


### PR DESCRIPTION
Идея: использовать подстановщик на исходной системе без лямбд. Уравнения с лямбдами все равно никогда не будут подстановочными. И подставлять в них не нужно: лучше сделать подстановку заранее и формировать их уже на основе упрощенной системы.

Что нужно сделать:
1. Сделать вызов подстановщика перед созданием лямбд и сделать восстановление результата.
2. Сделать удаление лишних символов после работы подстановщика (именно удаление, а не получение всех заново путем прохода по уравнениям).
3. Оптимизировать eq.subs (см. ноутбук) - нужно передавать сразу все подстановки и использовать сами символы, а не имена.